### PR TITLE
Add the ability to use custom HTTP client

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,9 +10,8 @@ import (
 // Origin is the constant origin URL for the Pocket API
 const Origin = "https://getpocket.com"
 
-// DefaultClient is the client used for making all request, defaulting to
-// http.DefaultClient
-var DefaultClient = http.DefaultClient
+// DefaultClient is the client used for making all requests
+var DefaultClient *http.Client
 
 // Client represents a Pocket client that grants OAuth access to your application
 type Client struct {

--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,8 @@ import (
 // Origin is the constant origin URL for the Pocket API
 const Origin = "https://getpocket.com"
 
+var httpClient = http.DefaultClient
+
 // Client represents a Pocket client that grants OAuth access to your application
 type Client struct {
 	authInfo
@@ -30,11 +32,17 @@ func NewClient(consumerKey, accessToken string) *Client {
 	}
 }
 
+// SetHTTPClient updates the package HTTP client.
+// Useful in cases where we need to use alternative clients "google.golang.org/appengine/urlfetch"
+func SetHTTPClient(c *http.Client) {
+	httpClient = c
+}
+
 func doJSON(req *http.Request, res interface{}) error {
 	req.Header.Add("X-Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -10,7 +10,9 @@ import (
 // Origin is the constant origin URL for the Pocket API
 const Origin = "https://getpocket.com"
 
-var httpClient = http.DefaultClient
+// DefaultClient is the client used for making all request, defaulting to
+// http.DefaultClient
+var DefaultClient = http.DefaultClient
 
 // Client represents a Pocket client that grants OAuth access to your application
 type Client struct {
@@ -35,14 +37,14 @@ func NewClient(consumerKey, accessToken string) *Client {
 // SetHTTPClient updates the package HTTP client.
 // Useful in cases where we need to use alternative clients "google.golang.org/appengine/urlfetch"
 func SetHTTPClient(c *http.Client) {
-	httpClient = c
+	DefaultClient = c
 }
 
 func doJSON(req *http.Request, res interface{}) error {
 	req.Header.Add("X-Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := httpClient.Do(req)
+	resp, err := DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 )
 
-// The API origin
-var Origin = "https://getpocket.com"
+// Origin is the constant origin URL for the Pocket API
+const Origin = "https://getpocket.com"
 
 // Client represents a Pocket client that grants OAuth access to your application
 type Client struct {


### PR DESCRIPTION
In cases to where it's not appropriate to use the default HTTP client, offer the option to override it.